### PR TITLE
Edit crate name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,8 +982,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-zk-sdk"
-version = "4.0.0"
+name = "solana-zk-sdk-arcium-fork"
+version = "4.0.2"
 dependencies = [
  "aes-gcm-siv",
  "base64",

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "solana-zk-sdk"
+name = "solana-zk-sdk-arcium-fork"
 description = "Solana ZK SDK"
 documentation = "https://docs.rs/solana-zk-sdk"
 version = "4.0.2"


### PR DESCRIPTION
We use this crate in arcium-tooling and while it has the same name as the upstream, we cannot use it in crates published on crates.io since that requires all dependencies to be published. So this PR changes the name so we can publish it.